### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   lint_test:
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["fastapi_injector/py.typed"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.7 <4.0"
+python = ">=3.7 <3.12"
 fastapi = ">=0.70.0"
 injector = ">=0.19.0"
 


### PR DESCRIPTION
- Add CI job for Python 3.11
- Add upper bound to supported versions in `pyproject.toml`