### PR TITLE
Allow to create request scopes outside of the middleware

### DIFF
--- a/fastapi_injector/__init__.py
+++ b/fastapi_injector/__init__.py
@@ -9,6 +9,7 @@ from fastapi_injector.injected import Injected, SyncInjected
 from fastapi_injector.request_scope import (
     InjectorMiddleware,
     RequestScope,
+    RequestScopeFactory,
     request_scope,
 )
 
@@ -20,5 +21,6 @@ __all__ = [
     "InjectorNotAttached",
     "request_scope",
     "RequestScope",
+    "RequestScopeFactory",
     "InjectorMiddleware",
 ]

--- a/tests/test_request_scope.py
+++ b/tests/test_request_scope.py
@@ -14,6 +14,7 @@ from fastapi_injector import (
     Injected,
     InjectorMiddleware,
     RequestScope,
+    RequestScopeFactory,
     attach_injector,
     request_scope,
 )
@@ -209,3 +210,25 @@ async def test_request_scope_cache_cleared(app_inj):
         await client.get("/")
 
     assert len(scope_instance.cache) == 0
+
+
+async def test_caches_instances_with_scope_factory():
+    class DummyInterface:
+        pass
+
+    class DummyImpl:
+        pass
+
+    inj = Injector()
+    inj.binder.bind(DummyInterface, to=DummyImpl, scope=request_scope)
+
+    factory = inj.get(RequestScopeFactory)
+
+    with factory.create_scope():
+        dummy1 = inj.get(DummyInterface)
+        dummy2 = inj.get(DummyInterface)
+        assert dummy1 is dummy2
+
+    with factory.create_scope():
+        dummy3 = inj.get(DummyInterface)
+        assert dummy1 is not dummy3


### PR DESCRIPTION
I started to implement something very similar to this project on my own, but was very happy to find this nice little library, which almost does all the stuff I need in order to use `injector` in my FastAPI application. So thanks for the work first of all!

However, it's lacking one particular feature: It would be great if there's a possibility to create request scopes also outside of the middleware. Background of this is that in my application I need to process messages I get from a message queue. Same as for requests it would be nice if it's possible to scope the lifetime of services to the handling of a single message. I could imagine there are more, similar cases where this might be helpful, for example background tasks (i.e. celery) or cronjobs. For sure I could write my own scope for this, but then I would more or less need to duplicate all of your work, so I thought it would make more sense to integrate it directly into your library.

To achieve this, I moved the logic of assigning request ids from the `InjectorMiddleware` to a new class called `RequestScopeFactory`, which allows create request scopes also outside the middleware. This could then be used for example like:

```py
class MessageHandler:
    def __init__(self, request_scope_factory: Inject[RequestScopeFactory]) -> None:
        self.request_scope_factory = request_scope_factory

    async def handle(self, message: Any) -> None:
        with self.request_scope_factory.create_scope():
            # process message
``` 

What do you think about this?