### PR TITLE
Bump dev tooling versions, drop support for Python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   lint_test:
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__/
 .pytest_cache
 venv
 .venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - fastapi
           - injector
   - repo: https://github.com/PyCQA/isort
-    rev: '5.11.4'
+    rev: '5.12.0'
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,18 @@ repos:
     hooks:
       - id: end-of-file-fixer
   - repo: https://github.com/psf/black
-    rev: '22.12.0'
+    rev: '23.3.0'
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.991'
+    rev: 'v1.3.0'
     hooks:
       - id: mypy
         additional_dependencies:
           - fastapi
           - injector
   - repo: https://github.com/pycqa/flake8
-    rev: '5.0.4'
+    rev: '6.0.0'
     hooks:
       - id: flake8
         additional_dependencies:
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/pylint
-    rev: 'v2.15.9'
+    rev: 'v3.0.0a6'
     hooks:
       - id: pylint
         files: fastapi_injector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["fastapi_injector/py.typed"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.7 <3.12"
+python = ">=3.8 <3.12"
 fastapi = ">=0.70.0"
 injector = ">=0.19.0"
 


### PR DESCRIPTION
Removing Python 3.7 support because isort no longer supports it (since [5.12.0](https://github.com/PyCQA/isort/releases/tag/5.12.0)).

Dropping language version support just because dev tooling no longer supports it isn't ideal, but the [EOL date for 3.7](https://peps.python.org/pep-0537/#and-beyond-schedule) is 2023-06-27, so I think it's OK to do it.