### PR TITLE
Add support for websockets

### DIFF
--- a/fastapi_injector/injected.py
+++ b/fastapi_injector/injected.py
@@ -1,6 +1,7 @@
 from typing import Any, TypeVar
 
-from fastapi import Depends, Request
+from fastapi import Depends
+from starlette.requests import HTTPConnection
 
 from fastapi_injector.attach import get_injector_instance
 
@@ -13,8 +14,8 @@ def Injected(interface: BoundInterface) -> Any:  # pylint: disable=invalid-name
     allowing you to use it in the route.
     """
 
-    async def inject_into_route(request: Request) -> BoundInterface:
-        return get_injector_instance(request.app).get(interface)
+    async def inject_into_route(conn: HTTPConnection) -> BoundInterface:
+        return get_injector_instance(conn.app).get(interface)
 
     return Depends(inject_into_route)
 
@@ -26,7 +27,7 @@ def SyncInjected(interface: BoundInterface) -> Any:  # pylint: disable=invalid-n
     with synchronous interfaces.
     """
 
-    def inject_into_route(request: Request) -> BoundInterface:
-        return get_injector_instance(request.app).get(interface)
+    def inject_into_route(conn: HTTPConnection) -> BoundInterface:
+        return get_injector_instance(conn.app).get(interface)
 
     return Depends(inject_into_route)


### PR DESCRIPTION
Hey it's me again 👋 

I noticed that `Injected` is currently not compatible with websocket routes. It fails with the following error:
```
TypeError: Injected.<locals>.inject_into_route() missing 1 required positional argument: 'request'
```

This PR adds support for that.