### PR TITLE
Maintenance, dependency upgrades 2023/11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   lint_test:
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,21 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.4.0'
+    rev: 'v4.5.0'
     hooks:
       - id: end-of-file-fixer
   - repo: https://github.com/psf/black
-    rev: '23.3.0'
+    rev: '23.11.0'
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.3.0'
+    rev: 'v1.7.0'
     hooks:
       - id: mypy
         additional_dependencies:
           - fastapi
           - injector
   - repo: https://github.com/pycqa/flake8
-    rev: '6.0.0'
+    rev: '6.1.0'
     hooks:
       - id: flake8
         additional_dependencies:
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/pylint
-    rev: 'v3.0.0a6'
+    rev: 'v3.0.1'
     hooks:
       - id: pylint
         files: fastapi_injector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8 <3.12"
+python = ">=3.8 <3.13"
 fastapi = ">=0.70.0"
 injector = ">=0.19.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ fastapi = ">=0.70.0"
 injector = ">=0.19.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.2.0"
-pytest-asyncio = ">=0.20.3,<0.22.0"
-pytest-cov = "^4.0.0"
-pre-commit = ">=2.21,<4.0"
-httpx = ">=0.23.3,<0.26.0"
+pytest = "^7.4.3"
+pytest-asyncio = "^0.21.1"
+pytest-cov = "^4.1.0"
+pre-commit = "^3.5.0"
+httpx = "^0.25.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- Apply `pre-commit autoupdate`.
- Add Python 3.12 to GitHub Actions testing grid.
- Update dev dependencies to latest.