### PR TITLE
Add deterministic cleanup of context manager dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ inj.binder.bind(ResourceFile, scope=request_scope)
 
 app = FastAPI()
 app.add_middleware(InjectorMiddleware, injector=inj)
-# Note the use of enable_cleanup
-attach_injector(app, inj, enable_cleanup=True)
+options = RequestScopeOptions(enable_cleanup=True)
+attach_injector(app, inj, options)
 ```
 
-By adding `enable_cleanup=True` when attaching the injector, the library ensures that the `ResourceFile.__exit__()` function is called at the end of the request, meaning that the file resource is released.
+By setting `enable_cleanup=True` in the `RequestScopeOptions`, the library ensures that the `ResourceFile.__exit__()` function is called at the end of the request, meaning that the file resource is released.
 
 ## Testing with fastapi-injector
 

--- a/fastapi_injector/__init__.py
+++ b/fastapi_injector/__init__.py
@@ -10,6 +10,7 @@ from fastapi_injector.request_scope import (
     InjectorMiddleware,
     RequestScope,
     RequestScopeFactory,
+    RequestScopeOptions,
     request_scope,
 )
 
@@ -20,6 +21,7 @@ __all__ = [
     "SyncInjected",
     "InjectorNotAttached",
     "request_scope",
+    "RequestScopeOptions",
     "RequestScope",
     "RequestScopeFactory",
     "InjectorMiddleware",

--- a/fastapi_injector/attach.py
+++ b/fastapi_injector/attach.py
@@ -1,12 +1,26 @@
 from fastapi import FastAPI
-from injector import Injector
+from injector import Injector, InstanceProvider, singleton
 
 from fastapi_injector.exceptions import InjectorNotAttached
+from fastapi_injector.request_scope import RequestScopeOptions
 
 
-def attach_injector(app: FastAPI, injector: Injector) -> None:
-    """Call this function on app startup to attach an injector to the app."""
+def attach_injector(app: FastAPI, injector: Injector, **kwargs) -> None:
+    """
+    Call this function on app startup to attach an injector to the app.
+
+    Supported kwargs:
+        * enable_cleanup
+
+            If True, dependencies that were created from the request scope will be
+            cleaned up when the scope is exited. Only dependencies that implement one
+            of the context manager protocols will be considered for cleanup.
+    """
     app.state.injector = injector
+    options = RequestScopeOptions(**kwargs)
+    injector.binder.bind(
+        RequestScopeOptions, InstanceProvider(options), scope=singleton
+    )
 
 
 def get_injector_instance(app: FastAPI) -> Injector:

--- a/fastapi_injector/attach.py
+++ b/fastapi_injector/attach.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import FastAPI
 from injector import Injector, InstanceProvider, singleton
 
@@ -5,19 +7,14 @@ from fastapi_injector.exceptions import InjectorNotAttached
 from fastapi_injector.request_scope import RequestScopeOptions
 
 
-def attach_injector(app: FastAPI, injector: Injector, **kwargs) -> None:
+def attach_injector(
+    app: FastAPI, injector: Injector, options: Optional[RequestScopeOptions] = None
+) -> None:
     """
     Call this function on app startup to attach an injector to the app.
-
-    Supported kwargs:
-        * enable_cleanup
-
-            If True, dependencies that were created from the request scope will be
-            cleaned up when the scope is exited. Only dependencies that implement one
-            of the context manager protocols will be considered for cleanup.
     """
     app.state.injector = injector
-    options = RequestScopeOptions(**kwargs)
+    options = options or RequestScopeOptions(enable_cleanup=False)
     injector.binder.bind(
         RequestScopeOptions, InstanceProvider(options), scope=singleton
     )

--- a/fastapi_injector/attach.py
+++ b/fastapi_injector/attach.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from fastapi import FastAPI
 from injector import Injector, InstanceProvider, singleton
 
@@ -8,13 +6,14 @@ from fastapi_injector.request_scope import RequestScopeOptions
 
 
 def attach_injector(
-    app: FastAPI, injector: Injector, options: Optional[RequestScopeOptions] = None
+    app: FastAPI,
+    injector: Injector,
+    options: RequestScopeOptions = RequestScopeOptions(),
 ) -> None:
     """
     Call this function on app startup to attach an injector to the app.
     """
     app.state.injector = injector
-    options = options or RequestScopeOptions(enable_cleanup=False)
     injector.binder.bind(
         RequestScopeOptions, InstanceProvider(options), scope=singleton
     )

--- a/fastapi_injector/request_scope.py
+++ b/fastapi_injector/request_scope.py
@@ -8,7 +8,7 @@ from contextlib import (
     asynccontextmanager,
 )
 from contextvars import ContextVar
-from typing import Any, Dict, Type
+from typing import Any, Dict, Optional, Type
 
 from injector import (
     Inject,
@@ -85,7 +85,7 @@ class RequestScope(Scope):
                 "Request ID missing in cache. "
                 "Make sure InjectorMiddleware has been added to the FastAPI instance."
             ) from exc
-        stack: AsyncExitStack | None = None
+        stack: Optional[AsyncExitStack] = None
         if self.options.enable_cleanup:
             if AsyncExitStack in self.cache[request_id]:
                 stack = self.cache[request_id][AsyncExitStack]

--- a/fastapi_injector/request_scope.py
+++ b/fastapi_injector/request_scope.py
@@ -8,6 +8,7 @@ from contextlib import (
     asynccontextmanager,
 )
 from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type
 
 from injector import (
@@ -26,19 +27,18 @@ from fastapi_injector.exceptions import RequestScopeError
 _request_id_ctx: ContextVar[uuid.UUID] = ContextVar("request_id")
 
 
+@dataclass
 class RequestScopeOptions:
     """
     Defines the behavioural options for a request scope.
-
-    Available options are:
-      * enable_cleanup
-            If True, dependencies that were created from the request scope will be
-            cleaned up when the scope is exited. Only dependencies that implement one
-            of the context manager protocols will be considered for cleanup.
     """
 
-    def __init__(self, **kwargs) -> None:
-        self.enable_cleanup = kwargs.get("enable_cleanup", False)
+    enable_cleanup: bool = False
+    """
+    If True, dependencies that were created from the request scope will be cleaned up
+    when the scope is exited. Only dependencies that implement one of the context
+    manager protocols will be considered for cleanup.
+    """
 
 
 class RequestScope(Scope):

--- a/fastapi_injector/request_scope.py
+++ b/fastapi_injector/request_scope.py
@@ -72,7 +72,9 @@ class RequestScope(Scope):
         self.cache = {}
         self._loop = asyncio.new_event_loop()
         self._thr = threading.Thread(
-            target=self._loop.run_forever, name="Async Runner", daemon=True
+            target=self._loop.run_forever,
+            name="fastapi-injector-enter-context",
+            daemon=True,
         )
 
     def get(self, key: Type[T], provider: Provider[T]) -> Provider[T]:

--- a/fastapi_injector/request_scope.py
+++ b/fastapi_injector/request_scope.py
@@ -1,5 +1,12 @@
+import asyncio
+import threading
 import uuid
-from contextlib import contextmanager
+from contextlib import (
+    AbstractAsyncContextManager,
+    AbstractContextManager,
+    AsyncExitStack,
+    asynccontextmanager,
+)
 from contextvars import ContextVar
 from typing import Any, Dict, Type
 
@@ -17,6 +24,21 @@ from starlette.types import Receive, Send
 from fastapi_injector.exceptions import RequestScopeError
 
 _request_id_ctx: ContextVar[uuid.UUID] = ContextVar("request_id")
+
+
+class RequestScopeOptions:
+    """
+    Defines the behavioural options for a request scope.
+
+    Available options are:
+      * enable_cleanup
+            If True, dependencies that were created from the request scope will be
+            cleaned up when the scope is exited. Only dependencies that implement one
+            of the context manager protocols will be considered for cleanup.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        self.enable_cleanup = kwargs.get("enable_cleanup", False)
 
 
 class RequestScope(Scope):
@@ -46,7 +68,12 @@ class RequestScope(Scope):
 
     def __init__(self, injector: Injector) -> None:
         super().__init__(injector)
+        self.options = injector.get(RequestScopeOptions)
         self.cache = {}
+        self._loop = asyncio.new_event_loop()
+        self._thr = threading.Thread(
+            target=self._loop.run_forever, name="Async Runner", daemon=True
+        )
 
     def get(self, key: Type[T], provider: Provider[T]) -> Provider[T]:
         try:
@@ -56,20 +83,60 @@ class RequestScope(Scope):
                 "Request ID missing in cache. "
                 "Make sure InjectorMiddleware has been added to the FastAPI instance."
             ) from exc
+        stack: AsyncExitStack | None = None
+        if self.options.enable_cleanup:
+            if AsyncExitStack in self.cache[request_id]:
+                stack = self.cache[request_id][AsyncExitStack]
+            else:
+                stack = self.cache[request_id][AsyncExitStack] = AsyncExitStack()
         if key in self.cache[request_id]:
             dependency = self.cache[request_id][key]
         else:
             dependency = provider.get(self.injector)
             self.cache[request_id][key] = dependency
+            if stack:
+                self._register(dependency, stack)
         return InstanceProvider(dependency)
 
     def add_key(self, key: uuid.UUID) -> None:
         """Add a new request key to the cache."""
         self.cache[key] = {}
 
-    def clear_key(self, key: uuid.UUID) -> None:
+    async def clear_key(self, key: uuid.UUID) -> None:
         """Clear the cache for a given request key."""
+        stack: AsyncExitStack = self.cache[key].get(AsyncExitStack, None)
+        if stack:
+            await stack.aclose()
         del self.cache[key]
+
+    def _register(self, obj: Any, stack: AsyncExitStack):
+        if isinstance(obj, AbstractContextManager):
+            stack.enter_context(obj)
+        elif isinstance(obj, AbstractAsyncContextManager):
+            self._enter_async_context(obj, stack)
+
+    def _enter_async_context(self, obj: Any, stack: AsyncExitStack) -> None:
+        # This is the classic "how to call async from sync" problem. See
+        # https://stackoverflow.com/a/74710015/260213 for a detailed explanation of how
+        # we solve this. In brief, we have a background thread that runs a separate
+        # event loop, and the async context is entered on that thread while the calling
+        # thread blocks
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:  # 'RuntimeError: There is no current event loop...'
+            # Starting new event loop
+            asyncio.run(stack.enter_async_context(obj))
+        else:
+            # Event loop is running, enter the context on a background thread
+            self._run_async(stack.enter_async_context(obj))
+
+    def _run_async(self, coroutine):
+        # This will block the calling thread until the coroutine is finished.
+        # Any exception that occurs in the coroutine is raised in the caller
+        if not self._thr.is_alive():
+            self._thr.start()
+        future = asyncio.run_coroutine_threadsafe(coroutine, self._loop)
+        return future.result()
 
 
 request_scope = ScopeDecorator(RequestScope)
@@ -83,8 +150,8 @@ class RequestScopeFactory:
     def __init__(self, request_scope_instance: Inject[RequestScope]) -> None:
         self.request_scope_instance = request_scope_instance
 
-    @contextmanager
-    def create_scope(self):
+    @asynccontextmanager
+    async def create_scope(self):
         """Creates a new request scope within dependencies are cached."""
         rid = uuid.uuid4()
         rid_ctx = _request_id_ctx.set(rid)
@@ -92,7 +159,7 @@ class RequestScopeFactory:
         try:
             yield
         finally:
-            self.request_scope_instance.clear_key(rid)
+            await self.request_scope_instance.clear_key(rid)
             _request_id_ctx.reset(rid_ctx)
 
 
@@ -110,5 +177,5 @@ class InjectorMiddleware:
         Add an identifier to the request
         that can be used retrieve scoped dependencies.
         """
-        with self.request_scope_factory.create_scope():
+        async with self.request_scope_factory.create_scope():
             await self.app(scope, receive, send)

--- a/tests/test_request_scope.py
+++ b/tests/test_request_scope.py
@@ -2,7 +2,7 @@ import abc
 import asyncio
 import time
 import uuid
-from typing import Self, Tuple
+from typing import Tuple
 
 import httpx
 import pytest
@@ -93,7 +93,7 @@ async def test_caches_instance_nested(app_inj):
 
 
 @pytest.mark.asyncio
-async def test_doesnt_cache_across_requests(app_inj):
+async def test_doesnt_cache_across_requests(app_inj) -> None:
     class DummyInterface:
         id: uuid.UUID
 
@@ -121,7 +121,7 @@ async def test_doesnt_cache_across_requests(app_inj):
 
 
 @pytest.mark.asyncio
-async def test_doesnt_cache_across_concurrent_requests(app_inj):
+async def test_doesnt_cache_across_concurrent_requests(app_inj) -> None:
     class DummyInterface:
         id: uuid.UUID
 
@@ -243,7 +243,7 @@ class DummyContextManager:
     def __init__(self) -> None:
         self.state = self.UNENTERED
 
-    def __enter__(self) -> Self:
+    def __enter__(self):
         self.state = self.ENTERED
         return self
 
@@ -259,7 +259,7 @@ class DummyAsyncContextManager:
     def __init__(self) -> None:
         self.state = self.UNENTERED
 
-    async def __aenter__(self) -> Self:
+    async def __aenter__(self):
         self.state = self.ENTERED
         return self
 


### PR DESCRIPTION
Resolves #17 

This PR adds deterministic cleanup of request-scoped dependencies that implement either of the `contextlib.AbstractContextManager` or `contextlib.AbstractAsyncContextManager` protocols (see [here](https://docs.python.org/3/library/contextlib.html) for details). Cleanup is enabled by passing the `enable_cleanup` keyword argument to `attach_injector()` with a value of `True` (see the README for an example).

Cleanup is achieved by maintaining a scoped `AsyncExitStack` and entering the context manager by using this stack whenever a matching dependency is resolved. The exit stack is closed (thereby triggering context cleanup) when the scope's key is cleared through `RequestScope.clear_key()`.

Note the need to run a background thread in order to resolve the "call async code from a sync function" problem, see `RequestScope._enter_async_context()` for details. This implies that all context managers are entered on the background thread - it's unlikely that this will cause a race condition, but one to be aware of.
