### PR TITLE
Set the middleware scope to starlette.types.Scope

### DIFF
--- a/fastapi_injector/request_scope.py
+++ b/fastapi_injector/request_scope.py
@@ -16,11 +16,11 @@ from injector import (
     Injector,
     InstanceProvider,
     Provider,
-    Scope,
     ScopeDecorator,
     T,
 )
-from starlette.types import Receive, Send
+from injector import Scope as InjectorScope
+from starlette.types import Receive, Scope, Send
 
 from fastapi_injector.exceptions import RequestScopeError
 
@@ -41,7 +41,7 @@ class RequestScopeOptions:
     """
 
 
-class RequestScope(Scope):
+class RequestScope(InjectorScope):
     """
     Caches dependencies within a single request.
     Needs the InjectorMiddleware to be installed to the FastAPI app.

--- a/fastapi_injector/request_scope.py
+++ b/fastapi_injector/request_scope.py
@@ -11,15 +11,9 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type
 
-from injector import (
-    Inject,
-    Injector,
-    InstanceProvider,
-    Provider,
-    ScopeDecorator,
-    T,
-)
+from injector import Inject, Injector, InstanceProvider, Provider
 from injector import Scope as InjectorScope
+from injector import ScopeDecorator, T
 from starlette.types import Receive, Scope, Send
 
 from fastapi_injector.exceptions import RequestScopeError


### PR DESCRIPTION
Small PR that distinguishes `injector.Scope` from `starlette.types.Scope`.