### PR TITLE
Make FastAPI an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ PyPI: https://pypi.org/project/fastapi-injector/
 pip install fastapi-injector
 ```
 
+`fastapi-injector` relies on your project using FastAPI as a dependency separately, but you can also get it installed automatically by using any of the extras.
+
+```shell
+# Installs `fastapi`
+pip install fastapi-injector[standard]
+
+# Installs `fastapi-slim`
+pip install fastapi-injector[slim]
+```
+
 ## Usage
 
 When creating your FastAPI app, attach the injector to it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,21 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8 <3.13"
-fastapi = ">=0.70.0"
+fastapi = { version = ">=0.70.0", optional = true }
+fastapi-slim = { version = ">=0.111.0", optional = true }
 injector = ">=0.19.0"
 
 [tool.poetry.group.dev.dependencies]
+fastapi-slim = ">=0.111.0"
+httpx = ">=0.25.1,<0.28.0"
+pre-commit = "^3.5.0"
 pytest = ">=7.4.3,<9.0.0"
 pytest-asyncio = ">=0.21.1,<0.24.0"
 pytest-cov = ">=4.1,<6.0"
-pre-commit = "^3.5.0"
-httpx = ">=0.25.1,<0.28.0"
+
+[tool.poetry.extras]
+standard = ["fastapi"]
+slim = ["fastapi-slim"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Fixes #29 

The current setup forces users to install the full `fastapi` package, but they may only want to use `fastapi-slim`. In order to allow for that, here I make `fastapi` an optional dependency and include `fastapi-slim` the same way, so that users can install either of them using either `fastapi-injector[standard]` or `fastapi-injector[slim]`.

With this approach we cannot directly enforce a minimum version for our FastAPI needs, but I _think_ Poetry helps us there as it analyses optionals too when resolving dependencies. In any case, this seems to be a more generally adopted setup, e.g. [the OpenTelemetry FastAPI instrumentation package](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/768694cf7578e6a211c42049c85ef7227eea6b48/instrumentation/opentelemetry-instrumentation-fastapi/pyproject.toml#L26-L37).

This new setup also relies on having `fastapi-slim` on both the main dependency list (as an optional extra) and in the dev group for testing. Not sure if there's a better way to reuse just 1 value...