### PR TITLE
Provide an accurate return type for Injected and SyncInjected

### DIFF
--- a/fastapi_injector/injected.py
+++ b/fastapi_injector/injected.py
@@ -1,33 +1,33 @@
-from typing import Any, TypeVar
+from typing import Any, Type, TypeVar
 
 from fastapi import Depends
 from starlette.requests import HTTPConnection
 
 from fastapi_injector.attach import get_injector_instance
 
-BoundInterface = TypeVar("BoundInterface", bound=type)
+T = TypeVar("T")
 
 
-def Injected(interface: BoundInterface) -> Any:  # pylint: disable=invalid-name
+def Injected(interface: Type[T]) -> T:
     """
     Asks your injector instance for the specified type,
     allowing you to use it in the route.
     """
 
-    async def inject_into_route(conn: HTTPConnection) -> BoundInterface:
+    async def inject_into_route(conn: HTTPConnection) -> T:
         return get_injector_instance(conn.app).get(interface)
 
     return Depends(inject_into_route)
 
 
-def SyncInjected(interface: BoundInterface) -> Any:  # pylint: disable=invalid-name
+def SyncInjected(interface: Type[T]) -> T:
     """
     Asks your injector instance for the specified type,
     allowing you to use it in the route. Intended for use
     with synchronous interfaces.
     """
 
-    def inject_into_route(conn: HTTPConnection) -> BoundInterface:
+    def inject_into_route(conn: HTTPConnection) -> T:
         return get_injector_instance(conn.app).get(interface)
 
     return Depends(inject_into_route)

--- a/fastapi_injector/injected.py
+++ b/fastapi_injector/injected.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, TypeVar
+from typing import Type, TypeVar
 
 from fastapi import Depends
 from starlette.requests import HTTPConnection
@@ -8,7 +8,7 @@ from fastapi_injector.attach import get_injector_instance
 T = TypeVar("T")
 
 
-def Injected(interface: Type[T]) -> T:
+def Injected(interface: Type[T]) -> T:  # pylint: disable=invalid-name
     """
     Asks your injector instance for the specified type,
     allowing you to use it in the route.
@@ -20,7 +20,7 @@ def Injected(interface: Type[T]) -> T:
     return Depends(inject_into_route)
 
 
-def SyncInjected(interface: Type[T]) -> T:
+def SyncInjected(interface: Type[T]) -> T:  # pylint: disable=invalid-name
     """
     Asks your injector instance for the specified type,
     allowing you to use it in the route. Intended for use

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,6 @@ relative_files = True
 
 [tool:pytest]
 asyncio_mode = auto
+
+[mypy]
+disable_error_code = type-abstract


### PR DESCRIPTION
### What

Specify return type for `Injected` and `SyncInjected`

### Why

Previously, the return type was `Any`. It was therefore necessary to specify the type of every injected argument like so

```python
def some_route(self, foo: Foo = Injected(Foo), bar: Bar = Injected(Bar)):
```

For developers who rely on a static type checker that infers argument types by default values (e.g. PyRight), this can now be simplified to 

```python
def some_route(self, foo=Injected(Foo), bar=Injected(Bar)):
```

without loss of type information.

As far as I can tell, mypy still doesn't infer argument types like PyRight does (see https://github.com/python/mypy/issues/3090). I have therefore left the code examples as-is.