### PR TITLE
Add new inject helpers for FastAPI requests

### DIFF
--- a/fastapi_injector/__init__.py
+++ b/fastapi_injector/__init__.py
@@ -5,7 +5,12 @@ Exposes a dependency wrapper to use in your routes.
 
 from fastapi_injector.attach import attach_injector, get_injector_instance
 from fastapi_injector.exceptions import InjectorNotAttached
-from fastapi_injector.injected import Injected, SyncInjected
+from fastapi_injector.injected import (
+    InjectConnection,
+    Injected,
+    SyncInjectConnection,
+    SyncInjected,
+)
 from fastapi_injector.request_scope import (
     InjectorMiddleware,
     RequestScope,
@@ -25,4 +30,6 @@ __all__ = [
     "RequestScope",
     "RequestScopeFactory",
     "InjectorMiddleware",
+    "InjectConnection",
+    "SyncInjectConnection",
 ]

--- a/fastapi_injector/__init__.py
+++ b/fastapi_injector/__init__.py
@@ -6,8 +6,10 @@ Exposes a dependency wrapper to use in your routes.
 from fastapi_injector.attach import attach_injector, get_injector_instance
 from fastapi_injector.exceptions import InjectorNotAttached
 from fastapi_injector.injected import (
+    InjectBody,
     InjectConnection,
     Injected,
+    SyncInjectBody,
     SyncInjectConnection,
     SyncInjected,
 )
@@ -32,4 +34,6 @@ __all__ = [
     "InjectorMiddleware",
     "InjectConnection",
     "SyncInjectConnection",
+    "InjectBody",
+    "SyncInjectBody",
 ]

--- a/fastapi_injector/injected.py
+++ b/fastapi_injector/injected.py
@@ -71,7 +71,8 @@ def SyncInjectBody(interface: Type[M]) -> M:  # pylint: disable=invalid-name
                 kind=Parameter.POSITIONAL_OR_KEYWORD,
                 annotation=Annotated[interface, Body()],
             ),
-        ]
+        ],
+        return_annotation=interface,
     )
 
     return Depends(_sync_bind_body)
@@ -104,7 +105,8 @@ def InjectBody(interface: Type[M]) -> M:  # pylint: disable=invalid-name
                 kind=Parameter.POSITIONAL_OR_KEYWORD,
                 annotation=Annotated[interface, Body()],
             ),
-        ]
+        ],
+        return_annotation=interface,
     )
 
     return Depends(_bind_body)

--- a/fastapi_injector/injected.py
+++ b/fastapi_injector/injected.py
@@ -1,13 +1,16 @@
-from typing import Any, Type, TypeVar
+from inspect import Parameter, Signature
+from typing import Annotated, Any, Type, TypeVar
 
-from fastapi import Depends, Request, WebSocket
+from fastapi import Body, Depends, Request, WebSocket
 from injector import InstanceProvider
+from pydantic import BaseModel
 from starlette.requests import HTTPConnection
 
 from fastapi_injector.attach import get_injector_instance
 from fastapi_injector.request_scope import request_scope
 
 T = TypeVar("T")
+M = TypeVar("M", bound=BaseModel)
 
 
 def _sync_bind_conn(conn: HTTPConnection) -> None:
@@ -38,6 +41,73 @@ def InjectConnection() -> Any:  # pylint: disable=invalid-name
     Intended to be used as a dependency of the FastAPI app instance.
     """
     return Depends(_bind_conn)
+
+
+def SyncInjectBody(interface: Type[M]) -> M:  # pylint: disable=invalid-name
+    """
+    Dependency to bind the deserialized pydantic body to the injector.
+    Intended for use with synchronous interfaces.
+    """
+
+    def _sync_bind_body(**kwargs: Any) -> BaseModel:
+        conn = kwargs["conn"]
+        body = kwargs["body"]
+        injector = get_injector_instance(conn.app)
+        injector.binder.bind(BaseModel, InstanceProvider(body), scope=request_scope)
+        return body
+
+    # workaround to allow for dynamic typing of the body in the function
+    # https://github.com/fastapi/fastapi/issues/2901#issuecomment-791593780
+    # https://github.com/python/typing/issues/598
+    _sync_bind_body.__signature__ = Signature(  # type: ignore[attr-defined]
+        [
+            Parameter(
+                name="conn",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=HTTPConnection,
+            ),
+            Parameter(
+                name="body",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Annotated[interface, Body()],
+            ),
+        ]
+    )
+
+    return Depends(_sync_bind_body)
+
+
+def InjectBody(interface: Type[M]) -> M:  # pylint: disable=invalid-name
+    """
+    Dependency to bind the deserialized pydantic body to the injector.
+    """
+
+    async def _bind_body(**kwargs: Any) -> BaseModel:
+        conn = kwargs["conn"]
+        body = kwargs["body"]
+        injector = get_injector_instance(conn.app)
+        injector.binder.bind(BaseModel, InstanceProvider(body), scope=request_scope)
+        return body
+
+    # workaround to allow for dynamic typing of the body in the function
+    # https://github.com/fastapi/fastapi/issues/2901#issuecomment-791593780
+    # https://github.com/python/typing/issues/598
+    _bind_body.__signature__ = Signature(  # type: ignore[attr-defined]
+        [
+            Parameter(
+                name="conn",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=HTTPConnection,
+            ),
+            Parameter(
+                name="body",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Annotated[interface, Body()],
+            ),
+        ]
+    )
+
+    return Depends(_bind_body)
 
 
 def Injected(interface: Type[T]) -> T:  # pylint: disable=invalid-name

--- a/fastapi_injector/injected.py
+++ b/fastapi_injector/injected.py
@@ -1,11 +1,43 @@
-from typing import Type, TypeVar
+from typing import Any, Type, TypeVar
 
-from fastapi import Depends
+from fastapi import Depends, Request, WebSocket
+from injector import InstanceProvider
 from starlette.requests import HTTPConnection
 
 from fastapi_injector.attach import get_injector_instance
+from fastapi_injector.request_scope import request_scope
 
 T = TypeVar("T")
+
+
+def _sync_bind_conn(conn: HTTPConnection) -> None:
+    injector = get_injector_instance(conn.app)
+    injector.binder.bind(HTTPConnection, InstanceProvider(conn), scope=request_scope)
+    if isinstance(conn, Request):
+        injector.binder.bind(Request, InstanceProvider(conn), scope=request_scope)
+    elif isinstance(conn, WebSocket):
+        injector.binder.bind(WebSocket, InstanceProvider(conn), scope=request_scope)
+
+
+async def _bind_conn(conn: HTTPConnection) -> None:
+    _sync_bind_conn(conn)
+
+
+def SyncInjectConnection() -> Any:  # pylint: disable=invalid-name
+    """
+    Dependency to bind request-related instances to the injector.
+    Intended to be used as a dependency of the FastAPI app instance.
+    Intended for use with synchronous interfaces.
+    """
+    return Depends(_sync_bind_conn)
+
+
+def InjectConnection() -> Any:  # pylint: disable=invalid-name
+    """
+    Dependency to bind request-related instances to the injector.
+    Intended to be used as a dependency of the FastAPI app instance.
+    """
+    return Depends(_bind_conn)
 
 
 def Injected(interface: Type[T]) -> T:  # pylint: disable=invalid-name
@@ -27,7 +59,7 @@ def SyncInjected(interface: Type[T]) -> T:  # pylint: disable=invalid-name
     with synchronous interfaces.
     """
 
-    def inject_into_route(conn: HTTPConnection) -> T:
+    def sync_inject_into_route(conn: HTTPConnection) -> T:
         return get_injector_instance(conn.app).get(interface)
 
-    return Depends(inject_into_route)
+    return Depends(sync_inject_into_route)


### PR DESCRIPTION
## What
Add new inject helpers for FastAPI request-related entities (connection, request, websocket) and for the deserialized pydantic body. `(Sync)InjectConnection` is intended to be used as a high level dependency, so that FastAPI does so for every route. `(Sync)InjectBody` is intended to be used either as a route dependency, to make it available for modules only, or as an actual injected dependency that yields the body model.

## Why
Currently there is no way to access request-related entities from module providers. This might be sometimes desired to consolidate the logic to perform some operations (e.g. auth) from a centralised place in a module.

Personally, I could benefit from having this, particularly to have access to the body. I could use it, even if it is typed as a generic `BaseModel`, in order to take advantage of the deserialized `pydantic` model, as opposed to the raw JSON body.

I chose the approach to create new helpers to use as dependencies as I couldn't think of a way to embed some of that in the middleware, not sure if it's the best approach though, happy to get some feedback! Also, not too convinced about the conditionals for Request/Websocket, maybe the user can do the check on HTTPConnection themselves instead? And how the body injection would play in the module when it's not been injected into that particular route, maybe we should somehow make it nullable? Or maybe that breaks the pattern? Anyway, let me know!

EDIT: I just realised that this implementation is also very order-dependant, i.e. if [these 2](https://github.com/matyasrichter/fastapi-injector/pull/38/files#diff-11a6fa3f7d3b33fc5f88c86547820b9b29ec5cd54e9913373907c63f620d8321R118-R119) are set the other way around, the injection does not work 😕 This approach might need a second thought...